### PR TITLE
Copy over the lock file, as well

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,7 @@ RUN apt-get update && \
   apt-get upgrade -y && \
   apt-get install -y libpq-dev jq
 
-# Try doing the bundle stuff first
-# COPY Gemfile Gemfile.lock $APP_DIR
-COPY Gemfile $APP_DIR
+COPY Gemfile Gemfile.lock $APP_DIR
 RUN bundle install
 
-# Copy the current directory contents into the container at /app
 COPY . $APP_DIR


### PR DESCRIPTION
# What

This commit moves over the lock file in the `Dockerfile` command. It was previously commented out because of some tomfoolery when doing local development.

# Why
I was trying to install Gems in Docker but didn't have a `Gemfile.lock`
file yet, so I removed the line that copied the lock file to generate a
`Gemfile.lock`. I never changed it back :(