### PR TITLE
Add users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem "bootsnap", ">= 1.4.4", require: false
 # gem "rack-cors"
 
 gem "httpx" # concurrent http client with an easy to use DSL
+gem "lockbox" # database encryption at the application layer
+gem "blind_index" # used for efficiently and safely querying encrypted models
 
 group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,11 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    argon2-kdf (0.1.6)
     ast (2.4.2)
+    blind_index (2.2.0)
+      activesupport (>= 5)
+      argon2-kdf (>= 0.1.1)
     bootsnap (1.7.7)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -82,6 +86,7 @@ GEM
     listen (3.6.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    lockbox (0.6.5)
     loofah (2.11.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -207,10 +212,12 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  blind_index
   bootsnap (>= 1.4.4)
   byebug
   httpx
   listen (~> 3.3)
+  lockbox
   pg (~> 1.1)
   pry
   puma (~> 5.0)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,4 @@
+class User < ApplicationRecord
+  encrypts :first_name, :last_name, :email
+  blind_index :email, slow: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,8 @@
 class User < ApplicationRecord
-  encrypts :first_name, :last_name, :email
+  encrypts :first_name, :last_name, :state, :email
+  encrypts :age, type: :integer
+
+  blind_index :first_name, slow: true
+  blind_index :last_name, slow: true
   blind_index :email, slow: true
 end

--- a/app/modules/configuration/lockbox.rb
+++ b/app/modules/configuration/lockbox.rb
@@ -1,0 +1,7 @@
+module Configuration
+  class Lockbox
+    extend Configurable
+
+    configure :lockbox
+  end
+end

--- a/app/services/spokeo/search.rb
+++ b/app/services/spokeo/search.rb
@@ -38,7 +38,7 @@ module Spokeo
 
     def find_listings
       responses = Rails.cache.fetch(search_url, expires_in: 12.hours) do
-        puts "No cache found! Fetching results, and caching."
+        Rails.logger.info "No cache found! Fetching results, and caching."
 
         if search_urls.size > 1
           HTTPX

--- a/config/initializers/lockbox.rb
+++ b/config/initializers/lockbox.rb
@@ -1,0 +1,1 @@
+Lockbox.master_key = Configuration::Lockbox.encryption_key

--- a/config/initializers/lockbox.rb
+++ b/config/initializers/lockbox.rb
@@ -1,1 +1,3 @@
-Lockbox.master_key = Configuration::Lockbox.encryption_key
+Rails.application.reloader.to_prepare do
+  Lockbox.master_key = Configuration::Lockbox.encryption_key
+end

--- a/config/lockbox.yml
+++ b/config/lockbox.yml
@@ -1,0 +1,11 @@
+defaults: &defaults
+  encryption_key: "0000000000000000000000000000000000000000000000000000000000000000"
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+production:
+  encryption_key: <%= ENV["LOCKBOX_ENCRYPTION_KEY"] %>

--- a/db/migrate/20210809023402_create_users.rb
+++ b/db/migrate/20210809023402_create_users.rb
@@ -1,0 +1,18 @@
+class CreateUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :users do |t|
+      # t.text :first_name
+      # t.text :last_name
+      # t.text :email
+      t.text :state
+
+      # We don't encrypt state because :shurg:
+      t.text :first_name_ciphertext
+      t.text :last_name_ciphertext
+      t.text :email_ciphertext
+      t.text :email_bidx, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210809023402_create_users.rb
+++ b/db/migrate/20210809023402_create_users.rb
@@ -1,15 +1,14 @@
 class CreateUsers < ActiveRecord::Migration[6.1]
   def change
     create_table :users do |t|
-      # t.text :first_name
-      # t.text :last_name
-      # t.text :email
-      t.text :state
-
-      # We don't encrypt state because :shurg:
       t.text :first_name_ciphertext
       t.text :last_name_ciphertext
       t.text :email_ciphertext
+      t.text :state_ciphertext
+      t.text :age_ciphertext
+
+      t.text :first_name_bidx, index: true
+      t.text :last_name_bidx, index: true
       t.text :email_bidx, index: { unique: true }
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2021_08_09_023402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.text "state"
+    t.text "first_name_ciphertext"
+    t.text "last_name_ciphertext"
+    t.text "email_ciphertext"
+    t.text "email_bidx"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email_bidx"], name: "index_users_on_email_bidx", unique: true
+  end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,14 +16,19 @@ ActiveRecord::Schema.define(version: 2021_08_09_023402) do
   enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
-    t.text "state"
     t.text "first_name_ciphertext"
     t.text "last_name_ciphertext"
     t.text "email_ciphertext"
+    t.text "state_ciphertext"
+    t.text "age_ciphertext"
+    t.text "first_name_bidx"
+    t.text "last_name_bidx"
     t.text "email_bidx"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email_bidx"], name: "index_users_on_email_bidx", unique: true
+    t.index ["first_name_bidx"], name: "index_users_on_first_name_bidx"
+    t.index ["last_name_bidx"], name: "index_users_on_last_name_bidx"
   end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,55 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "attributes" do
+    let(:instance) do
+      described_class.new(
+        first_name: "Roger",
+        last_name: "Klotz",
+        state: "PA",
+        email: "roger.klotz@gmail.com",
+        age: 25,
+      )
+    end
+
+    it "has all the correct attributes" do
+      expect(instance).to have_attributes(
+        first_name: "Roger",
+        last_name: "Klotz",
+        state: "PA",
+        email: "roger.klotz@gmail.com",
+        age: 25,
+      )
+    end
+  end
+
+  describe "encrypted attributes" do
+    let(:instance) do
+      described_class.new(
+        first_name: "Roger",
+        last_name: "Klotz",
+        state: "PA",
+        email: "roger.klotz@gmail.com",
+        age: 25,
+      )
+    end
+
+    before do
+      instance.save!
+    end
+
+    context "with a blind index" do
+      it "are searchable" do
+        expect(User.find_by(first_name: "Roger", last_name: "Klotz", email: "roger.klotz@gmail.com")).to eq(instance)
+      end
+    end
+
+    context "without a blind index" do
+      it "are not searchable" do
+        expect do
+          User.find_by(state: "PA", age: 25)
+        end.to raise_error(ActiveRecord::StatementInvalid, a_string_including("column users.state does not exist"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
# What

This pull request adds the `User` model to the application. It encrypts every attribute about the user. We use `blind_index` so that we can query encrypted columns (note: this has security implications that we just need to be aware of).

The blind indexed columns are:

- email (so that we can log the user in)
- first name (so that we can quickly correlate users to a result set from a data broker)
- last name (ditto as above).

# Why

As a user of this application, they will be able to see a list of data brokers that are around and which ones they have opted out of (and when).

We are encrypting this information at rest in the event that there is a compromise. In the future, we will be giving the users an option to completely delete their information from our apps,  so they remain totally secure.

# Example Screenshots

![image](https://user-images.githubusercontent.com/1649281/129050413-e9444b11-989a-4379-959b-01970788e881.png)
