### PR TITLE
Add user data brokers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development, :test do
   gem "rubocop-performance"
   gem "rubocop-rails"
   gem "rubocop-rspec"
+  gem "shoulda-matchers"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,8 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
+    shoulda-matchers (5.0.0)
+      activesupport (>= 5.2.0)
     spring (2.1.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -229,6 +231,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  shoulda-matchers
   spring
   tzinfo-data
 

--- a/app/models/data_broker.rb
+++ b/app/models/data_broker.rb
@@ -2,4 +2,15 @@ class DataBroker < ApplicationRecord
   OptOutTypes = [
     Form = "form".freeze
   ].freeze
+
+  Providers = [
+    Spokeo = "spokeo".freeze,
+    PeekYou = "peekyou".freeze,
+    Pipl = "pipl".freeze,
+    WhitePages = "whitepages".freeze,
+    Epsilon = "epsilon_data_management".freeze
+  ].freeze
+
+  has_many :user_data_brokers, dependent: :destroy
+  has_many :users, through: :user_data_brokers
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,7 @@ class User < ApplicationRecord
   blind_index :first_name, slow: true
   blind_index :last_name, slow: true
   blind_index :email, slow: true
+
+  has_many :user_data_brokers, dependent: :destroy
+  has_many :data_brokers, through: :user_data_brokers
 end

--- a/app/models/user_data_broker.rb
+++ b/app/models/user_data_broker.rb
@@ -1,0 +1,6 @@
+class UserDataBroker < ApplicationRecord
+  belongs_to :user
+  belongs_to :data_broker
+
+  scope :spokeo, -> { joins(:data_broker).where(data_brokers: { name: DataBroker::Spokeo }) }
+end

--- a/db/migrate/20210816032142_create_user_data_brokers.rb
+++ b/db/migrate/20210816032142_create_user_data_brokers.rb
@@ -1,0 +1,13 @@
+class CreateUserDataBrokers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_data_brokers do |t|
+      t.belongs_to :user
+      t.belongs_to :data_broker
+
+      t.text :status
+      t.datetime :opted_out_on
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_13_164402) do
+ActiveRecord::Schema.define(version: 2021_08_16_032142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,17 @@ ActiveRecord::Schema.define(version: 2021_08_13_164402) do
     t.text "notes"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "user_data_brokers", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "data_broker_id"
+    t.text "status"
+    t.datetime "opted_out_on"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["data_broker_id"], name: "index_user_data_brokers_on_data_broker_id"
+    t.index ["user_id"], name: "index_user_data_brokers_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/models/data_broker_spec.rb
+++ b/spec/models/data_broker_spec.rb
@@ -25,5 +25,20 @@ RSpec.describe DataBroker, type: :model do
     it "has opt out types" do
       expect(described_class::OptOutTypes).to contain_exactly("form")
     end
+
+    it "has valid providers" do
+      expect(described_class::Providers).to contain_exactly(
+        "spokeo",
+        "peekyou",
+        "pipl",
+        "whitepages",
+        "epsilon_data_management",
+      )
+    end
+  end
+
+  describe "relations" do
+    it { is_expected.to have_many(:user_data_brokers) }
+    it { is_expected.to have_many(:users).through(:user_data_brokers) }
   end
 end

--- a/spec/models/user_data_broker_spec.rb
+++ b/spec/models/user_data_broker_spec.rb
@@ -1,0 +1,26 @@
+describe UserDataBroker, type: :model do
+  let(:user) { User.new(email: "helmut.zero@gmail.com", age: 30, state: "CA") }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:data_broker) }
+  end
+
+  describe "scopes" do
+    context "with spokeo" do
+      it "returns matches that point to spokeo" do
+        spokeo = DataBroker.create(name: DataBroker::Spokeo)
+
+        described_class.create(user: user, data_broker: spokeo)
+
+        expect(described_class.spokeo).to include(
+          (
+            an_object_having_attributes(
+              data_broker_id: spokeo.id,
+            )
+          ),
+        )
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -56,4 +56,9 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "relations" do
+    it { is_expected.to have_many(:user_data_brokers) }
+    it { is_expected.to have_many(:data_brokers).through(:user_data_brokers) }
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,3 +64,10 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
# What

This pull request adds an association between users and data brokers, allowing us to keep track of all the data brokers the user has checked.

# Why

This will be used to keep track of which brokers we need to opt out of.