### PR TITLE
Add test rake task for Spokeo API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,13 @@ inherit_mode:
   merge:
     - Exclude
 
+# The `consistent` style enforces that the first element in an array
+# literal where the opening bracket and the first element are on
+# separate lines is indented the same as an array literal which is not
+# defined inside a method call.
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
 # Too short methods lead to extraction of single-use methods, which can make
 # the code easier to read (by naming things), but can also clutter the class
 Metrics/MethodLength: 
@@ -44,6 +51,12 @@ Style/Documentation:
   Enabled: false
 
 Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma
 
 Style/SymbolArray:

--- a/app/models/data_broker.rb
+++ b/app/models/data_broker.rb
@@ -1,6 +1,6 @@
 class DataBroker < ApplicationRecord
   OptOutTypes = [
-    Form = "form".freeze
+    Form = "form".freeze,
   ].freeze
 
   Providers = [
@@ -8,7 +8,7 @@ class DataBroker < ApplicationRecord
     PeekYou = "peekyou".freeze,
     Pipl = "pipl".freeze,
     WhitePages = "whitepages".freeze,
-    Epsilon = "epsilon_data_management".freeze
+    Epsilon = "epsilon_data_management".freeze,
   ].freeze
 
   has_many :user_data_brokers, dependent: :destroy

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,4 +64,6 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  config.log_level = :debug
 end

--- a/lib/tasks/spokeo.rake
+++ b/lib/tasks/spokeo.rake
@@ -18,7 +18,7 @@ namespace :spokeo do
 
     result = Spokeo::Search.run(name: name, state: state)
 
-    raise "Expected to get results for Spokeo search, but did not" if result.size == 0
+    raise "Expected to get results for Spokeo search, but did not" if result.empty?
 
     Rails.logger.tagged(rake_task.name) do
       Rails.logger.info { "OK" }

--- a/lib/tasks/spokeo.rake
+++ b/lib/tasks/spokeo.rake
@@ -4,11 +4,24 @@ require "pry"
 # This is an example request to Spokeo, and how it can return information about a person
 namespace :spokeo do
   task search: :environment do
+    # name = "Riley Claire"
+    # state = "Colorado"
+
+    # result = Spokeo::Search.run(name: name, state: state)
+    # search_result = Spokeo::Search.run(name: name, state: state)
+    # binding.pry
+  end
+
+  task test_search_connectivity: :environment do |rake_task|
     name = "Riley Claire"
     state = "Colorado"
 
     result = Spokeo::Search.run(name: name, state: state)
-    # search_result = Spokeo::Search.run(name: name, state: state)
-    binding.pry
+
+    raise "Expected to get results for Spokeo search, but did not" if result.size == 0
+
+    Rails.logger.tagged(rake_task.name) do
+      Rails.logger.info { "OK" }
+    end
   end
 end

--- a/spec/lib/tasks/spokeo_spec.rb
+++ b/spec/lib/tasks/spokeo_spec.rb
@@ -1,0 +1,34 @@
+# rubocop:disable RSpec/DescribeClass
+describe "spokeo rake tasks" do
+  include_context "when a rake task is tested"
+
+  let(:task_path) { "lib/tasks/spokeo" }
+
+  describe "test_search_connectivity" do
+    let(:task_name) { "spokeo:test_search_connectivity" }
+
+    context "when the search is not valid" do
+      before do
+        allow(Spokeo::Search).to receive(:run).and_return([])
+      end
+
+      it "raises an exception" do
+        expect { task.invoke }.to raise_exception(StandardError, /Expected to get results for Spokeo search/)
+      end
+    end
+
+    context "when the search returns results" do
+      before do
+        allow(Spokeo::Search).to receive(:run).and_return([
+          an_instance_of(Spokeo::Domain::Person),
+          an_instance_of(Spokeo::Domain::Person),
+        ])
+      end
+
+      it "is OK" do
+        expect { task.invoke }.not_to raise_error
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
## What

This pull request creates a test rake task that can be invoked on a cron, in order to verify that our Spokeo client is still functional.

It also sets up the Rails logger in "development" to output to STDOUT.

## Why

I haven't been able to commit to this repository on a consistent enough basis to understand the layout. Given how infrequently we work on it, it might be nice to ensure that our Ruby clients are still working.
